### PR TITLE
Fix name of the CocoaPods subspec in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,7 +7,7 @@ The Objective-C equivalents of this repo are in the UIKit extensions.
 ## CocoaPods
 
 ```ruby
-pod "PromiseKit/MessagesUI", "~> 6.0"
+pod "PromiseKit/MessageUI", "~> 6.0"
 ```
 
 The extensions are built into `PromiseKit.framework` thus nothing else is needed.


### PR DESCRIPTION
If you follow the installation method for pods outlined in README, you'll get the following error:

```
[!] CocoaPods could not find compatible versions for pod "PromiseKit/MessagesUI":
  In Podfile:
    PromiseKit/MessagesUI (~> 6.0)

None of your spec sources contain a spec satisfying the dependency: `PromiseKit/MessagesUI (~> 6.0)`.

You have either:
 * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.

Note: as of CocoaPods 1.0, `pod repo update` does not happen on `pod install` by default.
```

And then I noticed the subspec is named differently than the repo:

`s.subspec 'MessageUI' do |ss|`

This PR fixes pod installation instructions in the README file.